### PR TITLE
Added watch:releasePorts to free all ports that are taken be watchers and servers in dev mode

### DIFF
--- a/gulpConfig.js
+++ b/gulpConfig.js
@@ -1,8 +1,12 @@
-let autoprefixer = require('autoprefixer');
-let coreDependencies = require('ima/build.js');
-let path = require('path');
-let sharedTasksState = require('./gulpState');
-let macroTasks = require('./macroTasks.js');
+const autoprefixer = require('autoprefixer');
+const coreDependencies = require('ima/build.js');
+const path = require('path');
+
+const sharedTasksState = require('./gulpState');
+const macroTasks = require('./macroTasks.js');
+
+const environmentConfig = require(path.resolve('./app/environment.js'));
+const environment = require('ima-server/lib/environment')(environmentConfig);
 
 let appDependencies;
 try {
@@ -271,6 +275,12 @@ exports.files = {
     },
     postCssPlugins: []
   }
+};
+
+exports.occupiedPorts = {
+  'server': environment.$Server.port,
+  'livereload': exports.liveServer.port || 35729,
+  'fb-flo': 5888
 };
 
 exports.onTerminate = () => {

--- a/macroTasks.js
+++ b/macroTasks.js
@@ -3,6 +3,7 @@ const isProductionBuild = ['prod', 'production', 'test'].includes(
 );
 
 const DEFAULT_DEV_SUBTASKS = [
+  'watch:releasePorts',
   ['copy:appStatic', 'copy:environment', 'shim', 'polyfill'],
   ['Es6ToEs5:app', 'Es6ToEs5:server', 'Es6ToEs5:vendor'],
   ['less', 'doc', 'locale', 'Es6ToEs5:vendor:client'],

--- a/package.json
+++ b/package.json
@@ -27,12 +27,16 @@
         "registry": "https://registry.npmjs.org/"
     },
     "homepage": "https://github.com/seznam/IMA.js-gulp-tasks",
+    "peerDependencies": {
+        "ima-server": "^0.15.2"
+    },
     "devDependencies": {
         "babel-eslint": "^8.2.5",
         "eslint": "^5.3.0",
         "eslint-config-last": "^0.0.5",
         "eslint-config-prettier": "^3.0.1",
         "eslint-plugin-prettier": "^2.6.2",
+        "ima-server": "^0.15.2",
         "prettier": "^1.14.2"
     },
     "dependencies": {
@@ -78,7 +82,6 @@
         "gulp-watch": "^5.0.0",
         "ima-clientify": "^0.1.2",
         "ima-examples": "^0.15.1",
-        "ima-server": "^0.15.2",
         "loose-envify": "^1.4.0",
         "mkdirp": "^0.5.1",
         "vinyl-buffer": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
         "gulp-watch": "^5.0.0",
         "ima-clientify": "^0.1.2",
         "ima-examples": "^0.15.1",
+        "ima-server": "^0.15.2",
         "loose-envify": "^1.4.0",
         "mkdirp": "^0.5.1",
         "vinyl-buffer": "^1.0.1",

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -6,13 +6,15 @@ const remember = require('gulp-remember');
 const watch = require('gulp-watch');
 const path = require('path');
 const fs = require('fs');
+const { promisify } = require('util');
+const exec = promisify(require('child_process').exec);
 
 const sharedState = require('../gulpState.js');
 
 exports.__requiresConfig = true;
 
 exports.default = gulpConfig => {
-  let files = gulpConfig.files;
+  const { files, occupiedPorts } = gulpConfig;
 
   function watchTask() {
     let hotReloadedCacheKeys = [];
@@ -51,7 +53,7 @@ exports.default = gulpConfig => {
     flo(
       './build/static/',
       {
-        port: 5888,
+        port: occupiedPorts['fb-flo'],
         host: 'localhost',
         glob: ['**/*.css', '**/*.js']
       },
@@ -91,7 +93,26 @@ exports.default = gulpConfig => {
     }
   }
 
+  function checkAndReleasePorts() {
+    const occupants = Object.keys(occupiedPorts);
+    
+    gutil.log(`Releasing ports occupied by ${occupants.join(', ')}`);
+
+    return Promise.all(occupants.map(occupant => {
+      const port = occupiedPorts[occupant];
+
+      const command = process.platform === 'win32'
+        ? `Stop-Process -Id (Get-NetTCPConnection -LocalPort ${port}).OwningProcess -Force`
+        : `lsof -i:${port} | grep LISTEN | awk '{print $2}' | xargs kill -9`;
+
+      return exec(command).catch(() => {
+        throw Error(`Unable to free port ${port} occupied by ${occupant}. Try freeing this port manually.`);
+      });
+    }));
+  }
+
   return {
-    watch: watchTask
+    'watch': watchTask,
+    'watch:releasePorts': checkAndReleasePorts
   };
 };


### PR DESCRIPTION
- Added `ima-server` to dependencies. It's needed to obtain port number on which the server will run.
- Task `watch:releasePorts` is configured to be run first in the dev tasks series. This ensures that running `npm run dev` in another process will kill all watchers and servers in the original process.