### PR TITLE
Fix for locale´s scopes. 

### DIFF
--- a/tasks/locale.js
+++ b/tasks/locale.js
@@ -17,7 +17,7 @@ exports.default = gulpConfig => {
         .pipe(
           rename(path => {
             path.basename = path.basename.replace(
-              new RegExp(language, 'gi'),
+              new RegExp(language.toUpperCase(), 'g'),
               ''
             );
           })


### PR DESCRIPTION
How to reproduce the bug:

* set  languages = {en: ['./app/**/*EN.json']}; in app/build.js (like in IMA´s Examples)
* add file with translations with basename "entryEN.json"
* after build in the locale file is scope with name "try" insted of "entry"

Other e.g. eventEN => evt, enumEN =>um, etc...There is a lot of words with substring "en" in english. 

The language code is replaced in the basename of the file with translations globally. This fact leads to unpredictable behavior.

Solution in this fix is not perfect but not so unexpected as actual one.